### PR TITLE
ci: harden npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: npm-publish
 
+# SECURITY: default-deny GITHUB_TOKEN scope.
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]
@@ -38,14 +42,11 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Yarn Token
-        run: |
-          echo "npmAuthToken: ${{ secrets.NPM_AUTH_TOKEN }}" >> $HOME/.yarnrc.yml
-
       - name: Yarn Install
         if: steps.cache-yarn-packages.outputs.cache-hit != 'true'
-        run: yarn install # --frozen-lockfile
+        run: yarn install --immutable
         env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
   lint:
@@ -105,6 +106,9 @@ jobs:
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -127,13 +131,9 @@ jobs:
       - name: Yarn Build
         run: yarn build:prod
 
-      - name: Yarn Token
-        run: |
-          echo "npmAuthToken: ${{ secrets.NPM_AUTH_TOKEN }}" >> $HOME/.yarnrc.yml
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Yarn Publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: yarn npm publish
 
   # publish-s3:


### PR DESCRIPTION
## Summary

Minor CI hardening pass aligned with the rest of the Plitzi plugin repos.

### Commits

1. **ci: harden npm-publish workflow**
   - Add top-level default-deny `permissions:` so jobs only get the scopes they explicitly request.
   - Upgrade `publish-github` to the minimum scope (`contents:read` + `packages:write`).
   - Use `yarn install --immutable` so a push that quietly bumps a dependency cannot resolve to an unvetted version.
   - Drop the `Yarn Token` echo step that wrote the npm token into `$HOME/.yarnrc.yml`. The token now flows only through `YARN_NPM_AUTH_TOKEN` env so it never persists on the runner filesystem.

## Test plan

- [ ] Trigger workflow on a test branch — confirm jobs still pass with reduced permissions and `--immutable`.